### PR TITLE
zellijのレイアウトとデフォルトシェルの設定を変更

### DIFF
--- a/zellij/config.kdl
+++ b/zellij/config.kdl
@@ -292,7 +292,7 @@ theme "catppuccin-frappe"
 // Choose the path to the default shell that zellij will use for opening new panes
 // Default: $SHELL
 // 
-// default_shell "fish"
+default_shell "fish"
  
 // Choose the path to override cwd that zellij will use for opening new panes
 // 

--- a/zellij/layouts/default.kdl
+++ b/zellij/layouts/default.kdl
@@ -1,0 +1,21 @@
+layout {
+	tab name="Editor" {
+		pane split_direction="vertical" {
+			pane split_direction="horizontal" size="70%" {
+				pane command="hx" size="60%"
+				pane command="claude" size="40%" 
+			}
+			pane size="30%"
+		}
+		pane size=4 {
+			plugin location="zellij:status-bar"
+		}
+	
+	}
+	tab name="Git" {
+		pane command="lazygit"
+		pane size=4 {
+        	plugin location="zellij:status-bar"
+    	}
+	}
+}


### PR DESCRIPTION
zellijのレイアウトテンプレートを作成
Alacritty起動時にzellijを起動しようとかんがえたが、zellijは常に必要ではないのでその設定は取りやめた。